### PR TITLE
Makefile fix - install new files (bsc#1051340)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@
 *.m4
 *.ybc
 *.pot
+.yardoc
 .dep
 .deps
 .libs
+doc/
 package/*.bz2
 package/*.spec
 stamp-h*
@@ -32,7 +34,7 @@ libtool
 ltconfig
 ltmain.sh
 Makefile
-Makefile.am
+/Makefile.am
 Makefile.am.common
 Makefile.in
 missing

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 .libs
 doc/
 package/*.bz2
-package/*.spec
 stamp-h*
 aclocal.m4
 autodocs-cc.ami

--- a/package/yast2-rear.changes
+++ b/package/yast2-rear.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Aug  1 13:23:03 UTC 2017 - lslezak@suse.cz
+
+- Added missing files to the RPM package, the recently added
+  source files were not installed and packaged into the final RPM
+  (bsc#1051340)
+- 3.2.1
+
+-------------------------------------------------------------------
 Wed Feb  8 09:33:32 UTC 2017 - cwh@suse.com
 
 - Removed outdated checks for unsupported system configuration

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -58,6 +58,8 @@ The YaST2 component for configuring Rear - Relax and Recover Backup
 %{yast_clientdir}/rear.rb
 %{yast_moduledir}/RearSystemCheck.*
 %{yast_moduledir}/Rear.*
+%dir %{yast_libdir}/rear
+%{yast_libdir}/rear/*.rb
 %{yast_desktopdir}/rear.desktop
 %{yast_scrconfdir}/*.scr
 %doc %{yast_docdir}

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rear
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,12 +11,16 @@ yncludedir = @yncludedir@/rear
 ynclude_DATA = \
   include/rear/ui.rb
 
+ylibdir = "${yast2dir}/lib/rear"
+ylib_DATA = \
+  lib/rear/*.rb
+
 scrconf_DATA = \
   scrconf/rear_conf.scr
 
 desktop_DATA = \
   desktop/rear.desktop
 
-EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(desktop_DATA)
+EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(ylib_DATA) $(scrconf_DATA) $(desktop_DATA)
 
 include $(top_srcdir)/Makefile.am.common


### PR DESCRIPTION
- The module crashed hard (internal error) at start because of some missing files in the RPM package
- See [bsc#1051340](https://bugzilla.suse.com/show_bug.cgi?id=1051340)
- Because the module does not have unit tests at all the missing files were not noticed
- QA also did not find the issue :worried: 