### PR TITLE
[PoC] Travis integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-rear-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-rear-image bash -c "yast-travis-ruby && ./integration_test.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-rear-image bash -c "yast-travis-ruby && ./integration_test.sh"
+  # use "--privileged" so storage can access the devices
+  - docker run --privileged -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-rear-image bash -c "yast-travis-ruby && ./integration_test.sh"

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,0 +1,154 @@
+#! /bin/sh
+
+# exit on error immediately
+set -e
+
+function start_module()
+{
+  echo "Starting YaST module '$2'..."
+  # run "yast <module>" in a new tmux session (-d = detach, -s = session name)
+  # force 80x25 terminal size
+  tmux new-session -d -s $1 -x 80 -y 25 "yast $2"
+}
+
+function dump_screen()
+{
+  echo "----------------------- Screen Dump Begin -----------------------------"
+  if [ "$TRAVIS" == "1" ]; then
+    # the sed call transforms spaces to non-breakable UTF-8 spaces because
+    # Travis does not display a normal space sequence correctly
+    tmux capture-pane -e -p -t "$1" | sed 's/ /\xC2\xA0/g'
+  else
+    tmux capture-pane -e -p -t "$1"
+  fi
+  tput init
+  echo "----------------------- Screen Dump End -------------------------------"
+}
+
+function expect_text()
+{
+  if tmux capture-pane -p -t "$1" | grep -q "$2"; then
+    echo "Matched expected text: '$2'"
+  else
+    echo "ERROR: No match for expected text '$2'"
+    exit 1
+  fi
+}
+
+function not_expect_text()
+{
+  if tmux capture-pane -p -t "$1" | grep -q "$2"; then
+    echo "ERROR: Matched unexpected text: '$2'"
+    exit 1
+  fi
+}
+
+function send_keys()
+{
+  echo "Sending keys: $2"
+  tmux send-keys -t "$1" "$2"
+}
+
+function yast_exited()
+{
+  if tmux has-session "$1" 2> /dev/null; then
+    echo "ERROR: YaST is still running!"
+    exit 1
+  else
+    echo "YaST exited, OK"
+  fi
+}
+
+function skip_unsupported()
+{
+  # Bootloader is not configured (does not make sense in Docker),
+  # so there is a warning displayed.
+  if tmux capture-pane -p -t "$SESSION" | grep -q "This system is not supported by rear"; then
+    echo "Ignoring 'unsupported system' warning"
+    # Press "Ignore" (Alt-i shortcut)
+    send_keys $SESSION "M-i"
+    sleep 3
+  fi
+}
+
+# additionally install tmux
+# TODO: install tmux in the shared base Docker image
+zypper --non-interactive in --no-recommends tmux
+
+# install the built package
+# TODO: use zypper if the dependencies are really required:
+# zypper --non-interactive in --no-recommends /usr/src/packages/RPMS/*/*.rpm
+rpm -iv --force --nodeps /usr/src/packages/RPMS/*/*.rpm
+
+# name of the tmux session
+SESSION=yast2_rear
+
+
+###
+### Start the module and change one option
+###
+
+# run "yast rear" in a new session
+start_module $SESSION rear
+
+# wait a bit to ensure YaST is up
+# TODO: wait until the screen contains the expected text (with a timeout),
+# 3 seconds might not be enough on a slow or overloaded machine
+sleep 3
+
+dump_screen $SESSION
+not_expect_text $SESSION "Internal error"
+
+skip_unsupported
+ 
+dump_screen $SESSION
+expect_text $SESSION "Your ReaR configuration needs to be modified"
+# Press "OK" (F10 shortcut)
+send_keys $SESSION "F10"
+
+sleep 3
+dump_screen $SESSION
+expect_text $SESSION "Rear Configuration"
+
+# activate the "Boot Media" widget
+send_keys $SESSION "M-b"
+# select the "USB" option
+send_keys $SESSION "Down"
+send_keys $SESSION "Enter"
+
+sleep 1
+dump_screen $SESSION
+# ensure it is selected
+expect_text $SESSION "USB"
+not_expect_text $SESSION "ISO"
+
+# save the configuration
+send_keys $SESSION "F10"
+
+sleep 3
+yast_exited $SESSION
+
+###
+### Start the module again and check that the change was saved properly
+###
+
+start_module $SESSION rear
+# wait a bit to ensure YaST is up
+sleep 3
+
+skip_unsupported
+
+dump_screen $SESSION
+# USB should be selected as the boot medium
+expect_text $SESSION "USB"
+not_expect_text $SESSION "ISO"
+
+# abort
+send_keys $SESSION "F9"
+
+sleep 3
+yast_exited $SESSION
+
+
+# TODO: trap the signals and do a cleanup at the end
+# (kill YaST if it is still running, use tmux kill-session ?)

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -31,6 +31,8 @@ function expect_text()
     echo "Matched expected text: '$2'"
   else
     echo "ERROR: No match for expected text '$2'"
+    echo "y2log content:"
+    tail -n 50 /var/log/YaST2/y2log
     exit 1
   fi
 }
@@ -39,6 +41,8 @@ function not_expect_text()
 {
   if tmux capture-pane -p -t "$1" | grep -q "$2"; then
     echo "ERROR: Matched unexpected text: '$2'"
+    echo "y2log content:"
+    tail -n 50 /var/log/YaST2/y2log
     exit 1
   fi
 }

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -41,6 +41,9 @@ function not_expect_text()
 {
   if tmux capture-pane -p -t "$1" | grep -q "$2"; then
     echo "ERROR: Matched unexpected text: '$2'"
+    echo "/sys/ext_range:"
+    ls -l /sys/ext_range
+    cat /sys/ext_range
     echo "y2log content:"
     tail -n 50 /var/log/YaST2/y2log
     exit 1


### PR DESCRIPTION
- This is just a proof of concept to show that we can run some YaST integration tests directly at Travis
- This will prevent from trivial bugs like [bsc#1051340](https://bugzilla.suse.com/show_bug.cgi?id=1051340), [bsc#1051899](https://bugzilla.suse.com/show_bug.cgi?id=1051899)
- [This Travis log](https://travis-ci.org/yast/yast-rear/builds/259803414#L681) reproduces the internal error as reported in bugzilla, with this test it would have been found much earlier
- [This Travis log](https://travis-ci.org/yast/yast-rear/builds/260086828#L670) shows the fixed module and the full save & load workflow - this ensures the module runs and can save and read the config properly
- See also the [mail at yast-devel@](https://lists.opensuse.org/yast-devel/2017-08/msg00006.html)
