### PR TITLE
Rear version higher or equal 1.18 supports vfat partitions

### DIFF
--- a/package/yast2-rear.changes
+++ b/package/yast2-rear.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 15 17:23:26 UTC 2021 - aabdallah@suse.com
+
+- Don't show a warning anymore for vfat partitions, as versions
+  1.18 and higher of rear support them (bsc#1180599)
+
+-------------------------------------------------------------------
 Tue Dec 31 13:59:56 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Mark properly log widget label for translation (bsc#1083674)

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rear
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - Rear - Relax and Recover
 Group:          System/YaST

--- a/src/modules/RearSystemCheck.rb
+++ b/src/modules/RearSystemCheck.rb
@@ -93,6 +93,14 @@ module Yast
       devicegraph = Y2Storage::StorageManager.instance.probed
       supportedfs = [:ext2, :ext3, :ext4, :tmpfs, :swap, :none, :nfs, :nfs4, :btrfs, :xfs]
       unsupported = []
+      # Check rear version
+      rear_cmd_ver = "/usr/sbin/rear -V | cut -d' ' -f2";
+      out = SCR.Execute(path(".target.bash_output"), rear_cmd_ver);
+
+      # version >=1.18 supports  vfat partitions
+      if Gem::Version.new(Ops.get_string(out, "stdout", "")) >= Gem::Version.new("1.18")
+        supportedfs.push(:vfat);
+      end
 
       devicegraph.disk_devices.each do |device|
         # check devices


### PR DESCRIPTION
Add check for rear version, and for versions higher than or equal 1.18,
add vfat to the list of supported filesystem, see bsc#1180599 for more
details.