### PR TITLE
Rear version higher or equal 1.18 supports vfat partitions

### DIFF
--- a/package/yast2-rear.changes
+++ b/package/yast2-rear.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 19 11:23:26 UTC 2021 - aabdallah@suse.com
+
+- Don't show a warning anymore for vfat partitions, as versions
+  1.18 and higher of rear support them (bsc#1180599)
+- 3.2.2
+
+-------------------------------------------------------------------
 Tue Aug  1 13:23:03 UTC 2017 - lslezak@suse.cz
 
 - Added missing files to the RPM package, the recently added

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rear
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/RearSystemCheck.rb
+++ b/src/modules/RearSystemCheck.rb
@@ -93,6 +93,14 @@ module Yast
       storage = Storage.GetTargetMap
       supportedfs = [:ext2, :ext3, :ext4, :tmpfs, :swap, :none, :nfs, :nfs4, :btrfs, :xfs]
       unsupported = []
+      # Check rear version
+      rear_cmd_ver = "/usr/sbin/rear -V | cut -d' ' -f2";
+      out = SCR.Execute(path(".target.bash_output"), rear_cmd_ver);
+
+      # version >=1.18 supports  vfat partitions
+      if Gem::Version.new(Ops.get_string(out, "stdout", "")) >= Gem::Version.new("1.18")
+        supportedfs.push(:vfat);
+      end
 
       Builtins.foreach(storage) do |device, devicemap|
         # check devices


### PR DESCRIPTION
Add check for rear version, and for versions higher than or equal 1.18,
add vfat to the list of supported filesystem, see bsc#1180599 for more
details.