### PR TITLE
Fix quoting of values in POST_RECOVERY_SCRIPT and BACKUP_PROG_INCLUDE

### DIFF
--- a/package/yast2-rear.changes
+++ b/package/yast2-rear.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Jan 23 20:14:50 UTC 2021 - Petr Pavlu <petr.pavlu@suse.com>
+
+- Fix quoting of values in POST_RECOVERY_SCRIPT and
+  BACKUP_PROG_INCLUDE (bsc#1180983).
+- 4.2.2
+
+-------------------------------------------------------------------
 Tue Dec 31 13:59:56 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Mark properly log widget label for translation (bsc#1083674)

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rear
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - Rear - Relax and Recover
 Group:          System/YaST

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,0 +1,7 @@
+TESTS = \
+  rear_test.rb
+
+TEST_EXTENSIONS = .rb
+RB_LOG_COMPILER = rspec
+VERBOSE = 1
+EXTRA_DIST = $(TESTS)

--- a/test/rear_test.rb
+++ b/test/rear_test.rb
@@ -1,0 +1,119 @@
+#!/usr/bin/env rspec
+
+require_relative "./test_helper"
+
+Yast.import "Rear"
+
+describe Yast::Rear do
+  describe "#RearListToYCPList" do
+    it "correctly splits and parses a given input list" do
+      ycplist = subject.RearListToYCPList("()")
+      expect(ycplist).to eq([])
+
+      ycplist = subject.RearListToYCPList("(a)")
+      expect(ycplist).to eq(["a"])
+
+      ycplist = subject.RearListToYCPList("(a b  c)")
+      expect(ycplist).to eq(["a", "b", "c"])
+
+      ycplist = subject.RearListToYCPList("(a\\ b c)")
+      expect(ycplist).to eq(["a b", "c"])
+
+      ycplist = subject.RearListToYCPList("(a\\ \\ \\ b c)")
+      expect(ycplist).to eq(["a   b", "c"])
+
+      ycplist = subject.RearListToYCPList("(a* b)")
+      expect(ycplist).to eq(["a*", "b"])
+
+      ycplist = subject.RearListToYCPList("('a' b)")
+      expect(ycplist).to eq(["'a'", "b"])
+    end
+  end
+
+  describe "#YCPListToRearList" do
+    it "correctly transforms a given list for output" do
+      rearlist = subject.YCPListToRearList([])
+      expect(rearlist).to eq(("()"))
+
+      rearlist = subject.YCPListToRearList(["a"])
+      expect(rearlist).to eq("(a)")
+
+      rearlist = subject.YCPListToRearList(["a", "b", "c"])
+      expect(rearlist).to eq("(a b c)")
+
+      rearlist = subject.YCPListToRearList(["a b", "c"])
+      expect(rearlist).to eq("(a\\ b c)")
+
+      rearlist = subject.YCPListToRearList(["a   b", "c"])
+      expect(rearlist).to eq("(a\\ \\ \\ b c)")
+
+      rearlist = subject.YCPListToRearList(["a*", "b"])
+      expect(rearlist).to eq("(a* b)")
+
+      rearlist = subject.YCPListToRearList(["'a'", "b"])
+      expect(rearlist).to eq("('a' b)")
+    end
+  end
+
+  describe "#RearQuotedListToYCPList" do
+    it "correctly splits and parses a given input list" do
+      ycplist = subject.RearQuotedListToYCPList("()")
+      expect(ycplist).to eq([])
+
+      ycplist = subject.RearQuotedListToYCPList("(a)")
+      expect(ycplist).to eq(["a"])
+
+      ycplist = subject.RearQuotedListToYCPList("(a b  c)")
+      expect(ycplist).to eq(["a", "b", "c"])
+
+      ycplist = subject.RearQuotedListToYCPList("(a\\ b c)")
+      expect(ycplist).to eq(["a b", "c"])
+
+      ycplist = subject.RearQuotedListToYCPList("(a\\ \\ \\ b c)")
+      expect(ycplist).to eq(["a   b", "c"])
+
+      ycplist = subject.RearQuotedListToYCPList("(a* b)")
+      expect(ycplist).to eq(["a*", "b"])
+
+      ycplist = subject.RearQuotedListToYCPList("('a' b)")
+      expect(ycplist).to eq(["a", "b"])
+
+      ycplist = subject.RearQuotedListToYCPList("('a'\\''b' c)")
+      expect(ycplist).to eq(["a'b", "c"])
+
+      ycplist = subject.RearQuotedListToYCPList("('' a)")
+      expect(ycplist).to eq(["a"])
+    end
+  end
+
+  describe "#YCPListToRearQuotedList" do
+    it "correctly transforms a given list for output" do
+      rearlist = subject.YCPListToRearQuotedList([])
+      expect(rearlist).to eq("()")
+
+      rearlist = subject.YCPListToRearQuotedList(["a"])
+      expect(rearlist).to eq("('a')")
+
+      rearlist = subject.YCPListToRearQuotedList(["a", "b", "c"])
+      expect(rearlist).to eq("('a' 'b' 'c')")
+
+      rearlist = subject.YCPListToRearQuotedList(["a b", "c"])
+      expect(rearlist).to eq("('a b' 'c')")
+
+      rearlist = subject.YCPListToRearQuotedList(["a   b", "c"])
+      expect(rearlist).to eq("('a   b' 'c')")
+
+      rearlist = subject.YCPListToRearQuotedList(["a*", "b"])
+      expect(rearlist).to eq("('a*' 'b')")
+
+      rearlist = subject.YCPListToRearQuotedList(["a", "b"])
+      expect(rearlist).to eq("('a' 'b')")
+
+      rearlist = subject.YCPListToRearQuotedList(["a'b", "c"])
+      expect(rearlist).to eq("('a'\\''b' 'c')")
+
+      rearlist = subject.YCPListToRearQuotedList([""])
+      expect(rearlist).to eq("('')")
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,42 @@
+ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+
+require "yast"
+require "yast/rspec"
+
+# stable testing in localized env
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    # make sure we mock only the existing methods
+    mocks.verify_partial_doubles = true
+  end
+end
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  src_location = File.expand_path("../src", __dir__)
+  # track all ruby files under src
+  SimpleCov.track_files("#{src_location}/**/*.rb")
+
+  # additionally use the LCOV format for on-line code coverage reporting at CI
+  if ENV["CI"] || ENV["COVERAGE_LCOV"]
+    require "simplecov-lcov"
+
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      # this is the default Coveralls GitHub Action location
+      # https://github.com/marketplace/actions/coveralls-github-action
+      c.single_report_path = "coverage/lcov.info"
+    end
+
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::LcovFormatter
+    ]
+  end
+end


### PR DESCRIPTION
Add code to write a correctly quoted value of the `POST_RECOVERY_SCRIPT` variable in the ReaR configuration file and to read it back. The value was previously output only with escaped spaces which caused a problem for the snapper quota script as it contains various special characters. This then resulted in the following error when running ReaR (bsc#1180983):

    /etc/rear/local.conf: line 18: syntax error near unexpected token '|'