### PR TITLE
Build package only for supported architectures

### DIFF
--- a/package/yast2-rear.changes
+++ b/package/yast2-rear.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  7 13:46:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Build package only for supported architectures (bsc#1189646).
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-rear.changes
+++ b/package/yast2-rear.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Sep  7 13:46:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
-- Build package only for supported architectures (bsc#1189646).
+- Build the package only for supported architectures (bsc#1189646).
 - 4.4.2
 
 -------------------------------------------------------------------

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -39,7 +39,10 @@ Requires:       rear >= 1.10.0
 Requires:       yast2
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-storage-ng
-BuildArch:      noarch
+
+# Build package only for architectures supported by rear (bsc#1189646)
+# See https://github.com/rear/rear/blob/f06e0d22eeb3bd45ad8ce0b8fce0b538e4534f93/packaging/rpm/rear.spec#L27-L33
+ExclusiveArch: %ix86 x86_64 ppc ppc64 ppc64le ia64
 
 %description
 The YaST2 component for configuring Rear - Relax and Recover Backup

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rear
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Rear - Relax and Recover
 License:        GPL-2.0-only

--- a/package/yast2-rear.spec
+++ b/package/yast2-rear.spec
@@ -40,7 +40,7 @@ Requires:       yast2
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-storage-ng
 
-# Build package only for architectures supported by rear (bsc#1189646)
+# Build the package only for architectures supported by rear (bsc#1189646)
 # See https://github.com/rear/rear/blob/f06e0d22eeb3bd45ad8ce0b8fce0b538e4534f93/packaging/rpm/rear.spec#L27-L33
 ExclusiveArch: %ix86 x86_64 ppc ppc64 ppc64le ia64
 


### PR DESCRIPTION
## Problem

[rear](https://github.com/rear/rear) only works in [some architectures](https://github.com/rear/rear/blob/f06e0d22eeb3bd45ad8ce0b8fce0b538e4534f93/packaging/rpm/rear.spec#L27-L33) but yast-rear is built with `BuildArch: noarch` but requiring `rear` at the same time.

## Solution

Similarly to what was done in `rear` package, stop using `BuildArch: noarch` in favor of the [`ExclusiveArch`](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_arch_specific_runtime_and_build_time_dependencies) tag with supported archs.